### PR TITLE
Add parsing of "download dependencies"

### DIFF
--- a/src/Rosetta.Tests/JsonParserTests.cs
+++ b/src/Rosetta.Tests/JsonParserTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using NuGet.Versioning;
 using Shouldly;
 
 namespace Rosetta.Tests;
@@ -18,5 +20,54 @@ public sealed class JsonParserTests
 
         // Then
         model.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Should_Parse_Download_Dependencies()
+    {
+        // Given
+        var input = EmbeddedResourceReader.Read("Rosetta.Tests/Data/DotnetLibrary.json");
+
+        // When
+        var model = AssetFile.FromJson(input);
+
+        // Then
+        model.Project.Frameworks.ShouldContain(x => x.Name == "net6.0");
+        model.Project.Frameworks.ShouldContain(x => x.Name == "net5.0");
+        model.Project.Frameworks.ShouldContain(x => x.Name == "netstandard2.0");
+
+        var net6Target = model.Project.Frameworks.Single(x => x.Name == "net6.0");
+        net6Target.DownloadDependencies.ShouldSatisfyAllConditions(
+            x => x.Count.ShouldBe(1),
+            x => x.Single().Name.ShouldBe("Microsoft.NETCore.App.Ref"),
+            x => x.Single().VersionRange.ShouldBe(VersionRange.Parse("[3.0.0, 3.0.0]")));
+
+        var net5Target = model.Project.Frameworks.Single(x => x.Name == "net5.0");
+        net5Target.DownloadDependencies.ShouldSatisfyAllConditions(
+            x => x.Count.ShouldBe(1),
+            x => x.Single().Name.ShouldBe("Microsoft.NETCore.App.Ref"),
+            x => x.Single().VersionRange.ShouldBe(VersionRange.Parse("[3.0.0, 3.0.0]")));
+
+        var netstandardTarget = model.Project.Frameworks.Single(x => x.Name == "netstandard2.0");
+        netstandardTarget.DownloadDependencies.ShouldSatisfyAllConditions(
+            x => x.Count.ShouldBe(1),
+            x => x.Single().Name.ShouldBe("Microsoft.NETCore.App.Ref"),
+            x => x.Single().VersionRange.ShouldBe(VersionRange.Parse("[3.0.0, 3.0.0]")));
+    }
+
+    [Fact]
+    public void Should_Parse_Empty_Download_Dependencies()
+    {
+        // Given
+        var input = EmbeddedResourceReader.Read("Rosetta.Tests/Data/DotnetWebApp.json");
+
+        // When
+        var model = AssetFile.FromJson(input);
+
+        // Then
+        model.Project.Frameworks.ShouldHaveSingleItem();
+        var framework = model.Project.Frameworks.Single();
+        framework.DownloadDependencies.ShouldNotBeNull();
+        model.Project.Frameworks.Single().DownloadDependencies.ShouldBeEmpty();
     }
 }

--- a/src/Rosetta/DownloadDependency.cs
+++ b/src/Rosetta/DownloadDependency.cs
@@ -1,0 +1,16 @@
+namespace Rosetta;
+
+[DebuggerDisplay("{Name,nq} {VersionRange.OriginalString,nq}")]
+public sealed class DownloadDependency
+{
+    public string Name { get; }
+    public VersionRange VersionRange { get; }
+
+    public DownloadDependency(
+        string name,
+        VersionRange versionRange)
+    {
+        Name = name;
+        VersionRange = versionRange;
+    }
+}

--- a/src/Rosetta/Framework.cs
+++ b/src/Rosetta/Framework.cs
@@ -8,6 +8,7 @@ public sealed class Framework
     public IReadOnlySet<FrameworkDependency> Dependencies { get; }
     public IReadOnlySet<string> Imports { get; }
     public bool AssetTargetFallback { get; }
+    public IReadOnlySet<DownloadDependency> DownloadDependencies { get; }
     public string RuntimeIdentifierGraphPath { get; }
 
     public Framework(
@@ -15,12 +16,14 @@ public sealed class Framework
         IEnumerable<FrameworkDependency> dependencies,
         IEnumerable<string> imports,
         bool assetTargetFallback,
+        IEnumerable<DownloadDependency> downloadDependencies,
         string runtimeIdentifierGraphPath)
     {
         Name = name;
         TargetAlias = targetAlias;
         Dependencies = dependencies.ToReadOnlySet();
         Imports = imports.ToReadOnlySet();
+        DownloadDependencies = downloadDependencies.ToReadOnlySet();
         AssetTargetFallback = assetTargetFallback;
         RuntimeIdentifierGraphPath = runtimeIdentifierGraphPath;
     }

--- a/src/Rosetta/Internal/JsonModel.cs
+++ b/src/Rosetta/Internal/JsonModel.cs
@@ -74,6 +74,9 @@ internal sealed class JsonModel
             [JsonProperty("assetTargetFallback")]
             public bool AssetTargetFallback { get; set; }
 
+            [JsonProperty("downloadDependencies")]
+            public List<DownloadDependency>? DownloadDependencies { get; set; }
+
             [JsonProperty("runtimeIdentifierGraphPath")]
             public string? RuntimeIdentifierGraphPath { get; set; }
 
@@ -87,6 +90,15 @@ internal sealed class JsonModel
 
                 [JsonProperty("target")]
                 public string? Target { get; set; }
+
+                [JsonProperty("version")]
+                public string? Version { get; set; }
+            }
+
+            public sealed class DownloadDependency
+            {
+                [JsonProperty("name")]
+                public string? Name { get; set; }
 
                 [JsonProperty("version")]
                 public string? Version { get; set; }

--- a/src/Rosetta/Internal/JsonModelMapper.cs
+++ b/src/Rosetta/Internal/JsonModelMapper.cs
@@ -137,6 +137,7 @@ internal static class JsonModelMapper
                     dependencies: ParseFrameworkDependencies(framework.Dependencies),
                     imports: framework.Imports ?? Enumerable.Empty<string>(),
                     assetTargetFallback: framework.AssetTargetFallback,
+                    downloadDependencies: ParseDownloadDependencies(framework.DownloadDependencies),
                     runtimeIdentifierGraphPath: framework.RuntimeIdentifierGraphPath ?? string.Empty));
             }
         }
@@ -155,6 +156,27 @@ internal static class JsonModelMapper
                     dependencyName,
                     Enum.Parse<FrameworkDependencyTarget>(dependency.Target ?? "None"),
                     VersionRange.Parse(dependency.Version)));
+            }
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<DownloadDependency> ParseDownloadDependencies(List<JsonModel.Project.Framework.DownloadDependency>? downloadDependencies)
+    {
+        var result = new List<DownloadDependency>();
+        if (downloadDependencies != null)
+        {
+            foreach (var downloadDependency in downloadDependencies)
+            {
+                if (string.IsNullOrWhiteSpace(downloadDependency.Name))
+                {
+                    throw new InvalidOperationException("Encountered download dependency with empty package name");
+                }
+
+                result.Add(new DownloadDependency(
+                    downloadDependency.Name,
+                    VersionRange.Parse(downloadDependency.Version)));
             }
         }
 


### PR DESCRIPTION
Include the `downloadDependencies` section of the assets file in the object model.

"Download Dependencies" are packages that are downloaded by NuGet but not referenced.
AFAIK these are used by the SDK to pull in reference assemblies.